### PR TITLE
Mark `sql` files as generated, avoid Linguist over-interpretation

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Mark SQL files as "generated" so they get ignored in stats.
+*.sql linguist-generated

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
 # Mark SQL files as "generated" so they get ignored in stats.
-*.sql linguist-generated
+*.sql linguist-generated=true


### PR DESCRIPTION
Simply marks `*.sql` as generated so Linguist doesn't treat the project as mostly SQL.
Leaves the SQL files in-tact and un-effected.